### PR TITLE
Turn off packed_struct default features to avoid install serde unnece…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 
 [dependencies]
 arrayvec = "0.7"
-packed_struct = "0.6"
+packed_struct = { version = "0.6", default-features = false }
 packed_struct_codegen = "0.6"
 
 [dev-dependencies]


### PR DESCRIPTION
Using this crate in a project (it's solid thanks!) I noticed it builds serde. I don't see serde used anywhere in the crate so I tracked it down to `packed_struct`. Since chunkmap doesn't use it let's turn it off and save some compile time.

Before
```
$ time cargo build --release
________________________________________________________
Executed in   11.43 secs    fish           external
   usr time   27.30 secs    0.11 millis   27.30 secs
   sys time    2.23 secs    1.49 millis    2.22 secs

$ cargo tree
immutable-chunkmap v1.0.1 (/Users/n8ta/code/immutable-chunkmap)
├── arrayvec v0.7.2
├── packed_struct v0.6.1
│   ├── packed_struct_codegen v0.6.1 (proc-macro)
│   │   ├── proc-macro2 v1.0.43
│   │   │   └── unicode-ident v1.0.3
│   │   ├── quote v1.0.21
│   │   │   └── proc-macro2 v1.0.43 (*)
│   │   └── syn v1.0.99
│   │       ├── proc-macro2 v1.0.43 (*)
│   │       ├── quote v1.0.21 (*)
│   │       └── unicode-ident v1.0.3
│   └── serde v1.0.144  <=========== HERE
└── packed_struct_codegen v0.6.1 (proc-macro) (*)
```

After
```
$ time cargo build --release
________________________________________________________
Executed in   10.99 secs    fish           external
   usr time   20.56 secs    0.11 millis   20.56 secs
   sys time    1.67 secs    1.43 millis    1.67 secs

$ cargo tree
immutable-chunkmap v1.0.1 (/Users/n8ta/code/immutable-chunkmap)
├── arrayvec v0.7.2
├── packed_struct v0.6.1
│   └── packed_struct_codegen v0.6.1 (proc-macro)
│       ├── proc-macro2 v1.0.43
│       │   └── unicode-ident v1.0.3
│       ├── quote v1.0.21
│       │   └── proc-macro2 v1.0.43 (*)
│       └── syn v1.0.99
│           ├── proc-macro2 v1.0.43 (*)
│           ├── quote v1.0.21 (*)
│           └── unicode-ident v1.0.3
└── packed_struct_codegen v0.6.1 (proc-macro) (*)
```
