### PR TITLE
Unpack height and size for simplicity and fewer dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,11 @@ edition = "2018"
 
 [features]
 default = []
-serde = ["dep:serde", "packed_struct/use_serde"]
+serde = ["dep:serde"]
 rayon = ["dep:rayon"]
 
 [dependencies]
 arrayvec = "0.7"
-packed_struct = { version = "0.10", default-features = false }
-packed_struct_codegen = "0.10"
 serde = { version = "1", optional = true }
 rayon = { version = "1", optional = true }
 


### PR DESCRIPTION
Most of the required dependencies of `immutable-chunkmap`, including heavy dependencies like `syn`, come from the dependency on `packed_struct` (more specifically, `packed_struct_codegen`). To keep this crate's transitive dependencies lean and its impact on compile time to a minimum, I'd like to eliminate the dependency on `packed_struct`. It would be straightforward to hand-write packing and unpacking functions, but to keep things as simple as possible, I think it would be better to not pack the `height` and `size_of_children` fields at all. A few extra bytes per chunk isn't bad.