### PR TITLE
Implement `get_or_default_cow` using `get_or_insert_cow`

### DIFF
--- a/src/avl.rs
+++ b/src/avl.rs
@@ -1456,22 +1456,6 @@ where
 
 impl<K, V, const SIZE: usize> Tree<K, V, SIZE>
 where
-    K: Ord + Clone,
-    V: Clone + Default,
-{
-    pub(crate) fn get_or_default_cow<'a>(&'a mut self, k: K) -> &'a mut V {
-        match self.get_mut_cow(&k).map(|v| v as *mut V) {
-            Some(v) => unsafe { &mut *v },
-            None => {
-                self.insert_cow(k.clone(), V::default());
-                self.get_mut_cow(&k).unwrap()
-            }
-        }
-    }
-}
-
-impl<K, V, const SIZE: usize> Tree<K, V, SIZE>
-where
     K: Ord + Clone + Debug,
     V: Clone + Debug,
 {

--- a/src/map.rs
+++ b/src/map.rs
@@ -761,7 +761,7 @@ where
     /// Same as `get_mut_cow` except if the value isn't in the map it will
     /// be added by calling `V::default`
     pub fn get_or_default_cow<'a>(&'a mut self, k: K) -> &'a mut V {
-        self.0.get_or_default_cow(k)
+        self.get_or_insert_cow(k, V::default)
     }
 }
 


### PR DESCRIPTION
Since `get_or_default_cow` is really just a convenient special case of `get_or_insert_cow`, we shouldn't duplicate the logic between these two functions. This also eliminates one occurrence of `unsafe`.